### PR TITLE
Use libc to perform memfd syscall and drop sc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ homepage = "https://github.com/myfreeweb/shmemfdrs"
 repository = "https://github.com/myfreeweb/shmemfdrs"
 
 [dependencies]
-libc = "0.2"
-sc = { version = "0.2", optional = true }
+libc = "0.2.33"
 
 [features]
-memfd = ["sc"]
+memfd = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
 extern crate libc;
-#[cfg(all(feature="memfd", target_os="linux"))]
-#[macro_use]
-extern crate sc;
 
 use std::ffi::CStr;
 use libc::{c_int, off_t};
@@ -43,7 +40,7 @@ pub fn create_shmem<T: AsRef<CStr>>(name: T, length: usize) -> c_int {
 
 #[cfg(all(feature="memfd", target_os="linux"))]
 unsafe fn memfd_create(name: *const libc::c_char, flags: usize) -> c_int {
-    syscall!(MEMFD_CREATE, name, flags) as c_int
+    libc::syscall(libc::SYS_memfd_create, name, flags) as c_int
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `sc` crate uses the unstable `asm` feature, which means it won't compile on stable Rust. `libc` now has the ability to perform the `memfd` syscall so this PR drops `sc` in favour of using that, which means the `memfd` feature now works on stable Rust.